### PR TITLE
Mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ guitar_sounds/
 
 # AI tool config
 .claude/
+.agents/
+skills-lock.json
 
 # Editor directories and files
 .vscode/*

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,11 +67,13 @@ function getInitialState(
   solvedOnAttempt: number | null;
 } {
   if (saved) {
-    const guesses = hydrateGuesses(saved.guesses, challenge, songList);
+    // Clamp in memory only — treat >maxGuesses as a failed game, no write-back
+    const rawTitles = saved.guesses.slice(0, challenge.maxGuesses);
+    const guesses = hydrateGuesses(rawTitles, challenge, songList);
     if (saved.solved) {
       return { gameState: "done", guesses, solved: true, solvedOnAttempt: saved.solvedOnAttempt };
     }
-    if (saved.guesses.length >= challenge.maxGuesses) {
+    if (rawTitles.length >= challenge.maxGuesses) {
       return { gameState: "done", guesses, solved: false, solvedOnAttempt: null };
     }
     return { gameState: "idle", guesses, solved: false, solvedOnAttempt: null };
@@ -162,12 +164,12 @@ export default function App() {
   }, []);
 
   const handleStop = useCallback(() => {
-    setGameState("idle");
-  }, []);
+    setGameState(isFinished ? "done" : "idle");
+  }, [isFinished]);
 
   const handlePlaybackComplete = useCallback(() => {
-    setGameState("idle");
-  }, []);
+    setGameState(isFinished ? "done" : "idle");
+  }, [isFinished]);
 
   const handleSkip = useCallback(() => {
     const newGuesses = [...guesses, { text: "-", artistMatch: false, gameMatch: false }];
@@ -268,7 +270,7 @@ export default function App() {
       <GuessInput
         onGuess={handleGuess}
         onSkip={handleSkip}
-        disabled={!canGuess || isPlaying}
+        disabled={!canGuess || isPlaying || isFinished}
         attemptsLeft={challenge.maxGuesses - guesses.length}
       />
 

--- a/src/components/ResultModal.tsx
+++ b/src/components/ResultModal.tsx
@@ -322,7 +322,8 @@ export default function ResultModal({
       url: window.location.origin,
     };
 
-    if (typeof navigator.share === "function") {
+    const isMobile = /Mobile|Android|iPhone|iPad/i.test(navigator.userAgent)
+    if (isMobile && typeof navigator.share === "function") {
       try {
         await navigator.share(shareData);
         setShareState("shared");

--- a/src/components/WhatsNewModal.tsx
+++ b/src/components/WhatsNewModal.tsx
@@ -3,12 +3,19 @@ import { Button } from "./ui/button";
 
 // Bump this string whenever new features ship that returning users should know about.
 // Format: "YYYY-MM-DD" matching the deploy date.
-const CURRENT_VERSION = "2026-04-01";
+const CURRENT_VERSION = "2026-04-12";
 
 const WELCOME_KEY = "strumdle-welcome-seen";
 const SEEN_KEY = "strumdle-whats-new-seen";
 
 const UPDATES: { version: string; items: string[] }[] = [
+  {
+    version: "2026-04-12",
+    items: [
+      "Fixed Chrome on desktop share button opening a share dialog instead of copying a shareable text.",
+      "Fixed a bug that let you guess more than 6 times, such results are now treated as failures.",
+    ],
+  },
   {
     version: "2026-04-01",
     items: [

--- a/tests/replay-exploit.spec.ts
+++ b/tests/replay-exploit.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for the replay exploit fix.
+ *
+ * The exploit: after using all 6 guesses, clicking Replay then Stop (or letting
+ * playback complete) re-enabled the guess input, letting the player guess again.
+ *
+ * The fix:
+ * - handleStop / handlePlaybackComplete check isFinished and set "done" instead of "idle"
+ * - GuessInput is also disabled when isFinished, as a belt-and-suspenders guard
+ * - getInitialState clamps >maxGuesses guesses in memory (treats as failed, no write-back)
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+
+async function skipAll(page: Page, times = 6) {
+  for (let i = 0; i < times; i++) {
+    await page.getByRole("button", { name: "Skip" }).click();
+  }
+}
+
+async function dismissModal(page: Page) {
+  await page.getByRole("button", { name: "×" }).click();
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/1");
+  await page.evaluate(() => {
+    localStorage.clear();
+    localStorage.setItem("strumdle-welcome-seen", "1");
+    localStorage.setItem("strumdle-whats-new-seen", "9999-12-31");
+  });
+  await page.goto("/1");
+});
+
+test("guess input is disabled after replay+stop when game is over", async ({ page }) => {
+  await skipAll(page);
+  await dismissModal(page);
+
+  // Replay then immediately stop
+  await page.getByRole("button", { name: "Replay" }).click();
+  await page.getByRole("button", { name: "Stop" }).click();
+
+  await expect(page.getByRole("textbox")).toBeDisabled();
+});
+
+test("guess input is disabled after replay+playback-complete when game is over", async ({ page }) => {
+  await skipAll(page);
+  await dismissModal(page);
+
+  // Replay and wait for playback to complete naturally (or skip button reappears)
+  await page.getByRole("button", { name: "Replay" }).click();
+  // Stop it to avoid waiting full duration
+  await page.getByRole("button", { name: "Stop" }).click();
+
+  // Either way, input must remain disabled
+  await expect(page.getByRole("textbox")).toBeDisabled();
+});
+
+test("guess count in localStorage stays at 6 after replay+stop exploit attempt", async ({ page }) => {
+  await skipAll(page);
+  await dismissModal(page);
+
+  await page.getByRole("button", { name: "Replay" }).click();
+  await page.getByRole("button", { name: "Stop" }).click();
+
+  // Input is disabled, so we can't actually submit, but verify localStorage too
+  const guessCount = await page.evaluate(() => {
+    const raw = localStorage.getItem("daily-2020-01-01");
+    if (!raw) return -1;
+    return JSON.parse(raw).guesses.length;
+  });
+  expect(guessCount).toBe(6);
+});
+
+test("localstorage with more than 6 guesses is treated as a failed finished game", async ({ page }) => {
+  // Manually inject 8 guesses into localStorage (simulating the old exploit).
+  // Use a unique URL to prevent mobile-safari BFCache from restoring the prior
+  // React state instead of re-running JS with the new localStorage data.
+  await page.evaluate(() => {
+    localStorage.setItem(
+      "daily-2020-01-01",
+      JSON.stringify({
+        date: "2020-01-01",
+        guesses: ["-", "-", "-", "-", "-", "-", "-", "-"],
+        solved: false,
+        solvedOnAttempt: null,
+      }),
+    );
+  });
+
+  await page.goto("/1?_t=exploit");
+
+  // Game should be in "done" state — modal opens, input is disabled
+  await expect(page.getByRole("textbox")).toBeDisabled();
+  // Only 6 rows in the guess list (clamped)
+  await expect(page.getByTestId("guess-entry")).toHaveCount(6);
+});

--- a/tests/whatsnew.spec.ts
+++ b/tests/whatsnew.spec.ts
@@ -22,7 +22,7 @@ test("returning visitor who already saw current version does not see modal again
   await page.evaluate(() => {
     localStorage.clear();
     localStorage.setItem("strumdle-welcome-seen", "1");
-    localStorage.setItem("strumdle-whats-new-seen", "2026-04-01");
+    localStorage.setItem("strumdle-whats-new-seen", "2026-04-12");
   });
   await page.goto("/");
   await expect(page.getByText("What's New")).not.toBeVisible();
@@ -40,7 +40,7 @@ test("dismissing whats new modal stores current version and hides modal", async 
   await expect(page.getByText("What's New")).not.toBeVisible();
 
   const seen = await page.evaluate(() => localStorage.getItem("strumdle-whats-new-seen"));
-  expect(seen).toBe("2026-04-01");
+  expect(seen).toBe("2026-04-12");
 });
 
 test("returning visitor who has seen a newer version does not see modal", async ({ page }) => {


### PR DESCRIPTION
fix desktop sharing invoking win11 share dialog, now it copies the result to clipboard as intended
fixed being able to guess more than 6 times by pressing replay and stop after depleting guesses